### PR TITLE
feat: adoption-post crud, banner/bannerContent crud

### DIFF
--- a/nest_server/src/app.module.ts
+++ b/nest_server/src/app.module.ts
@@ -23,7 +23,9 @@ import entities from './entities';
       }),
     }),
     GraphQLModule.forRoot({
+      playground: process.env.NODE_ENV !== 'production',
       autoSchemaFile: true,
+      // installSubscriptionHandlers: true,
       context: ({ req, connection }) => {
         // if apply global guard, get token from GqlExecutionContext
         const HEADER_TOKEN_KEY = 'x-jwt';

--- a/nest_server/src/entities/adopt-user.entity.ts
+++ b/nest_server/src/entities/adopt-user.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { CoreDateEntity } from 'src/entities/common/core.entity';
 import { User } from './user.entity';
@@ -8,10 +8,14 @@ import { User } from './user.entity';
 @Entity()
 export class AdoptUser extends CoreDateEntity {
   // PK ref User.id
-  @OneToOne(() => User, { primary: true, cascade: true, onDelete: 'CASCADE'})
-  @JoinColumn()
+  @OneToOne(() => User, { primary: true, cascade: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
   @Field(() => User, { nullable: true })
   user: User;
+
+  // PK ref User.id
+  @PrimaryColumn()
+  userId: number;
 
   @Column({ nullable: false })
   @Field(() => String, { nullable: true })

--- a/nest_server/src/entities/adoption-post.entity.ts
+++ b/nest_server/src/entities/adoption-post.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, JoinColumn, ManyToOne, OneToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToOne,
+  RelationId,
+} from 'typeorm';
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { CoreEntity } from './common/core.entity';
 import { AdoptUser } from './adopt-user.entity';
@@ -11,11 +18,11 @@ import { Pets } from './pets.entity';
 @Entity()
 export class AdoptionPost extends CoreEntity {
   @ManyToOne(() => AdoptUser)
-  @JoinColumn()
+  @JoinColumn({ name: 'writterId' })
   @Field(() => AdoptUser, { nullable: true })
   writter: AdoptUser;
 
-  @OneToOne(() => Pets)
+  @OneToOne(() => Pets, (pet) => pet.id, { cascade: true })
   @JoinColumn()
   @Field(() => Pets, { nullable: true })
   pet: Pets;

--- a/nest_server/src/entities/pets.entity.ts
+++ b/nest_server/src/entities/pets.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, RelationId } from 'typeorm';
 import { Field, InputType, ObjectType } from '@nestjs/graphql';
 import { CoreEntity } from 'src/entities/common/core.entity';
 import { AdoptUser } from 'src/entities/adopt-user.entity';
@@ -31,7 +31,7 @@ export enum PetType {
 @Entity()
 export class Pets extends CoreEntity {
   @ManyToOne(() => AdoptUser)
-  @JoinColumn()
+  @JoinColumn({ name: 'registrantId' })
   @Field(() => AdoptUser, { nullable: true })
   registrant: AdoptUser;
 

--- a/nest_server/src/entities/user.entity.ts
+++ b/nest_server/src/entities/user.entity.ts
@@ -5,6 +5,7 @@ import { Column, Entity, Unique } from 'typeorm';
 export enum UserType {
   ADOPT = 'ADOPT_USER',
   ADOPTEE = 'ADOPTEE_USER',
+  ADMIN = 'ADMIN',
 }
 
 @InputType({ isAbstract: true })

--- a/nest_server/src/modules/adoption-post/adoption-post.module.ts
+++ b/nest_server/src/modules/adoption-post/adoption-post.module.ts
@@ -2,12 +2,15 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdoptionPost } from 'src/entities/adoption-post.entity';
 import { Pets } from 'src/entities/pets.entity';
+import { AuthService } from '../auth/auth.service';
+import { JwtService } from '../auth/jwt.service';
 import { PetService } from '../pet/pet.service';
 import {
   AdopteeUserRepository,
   AdoptUserRepository,
   UserRepository,
 } from '../user/user.repository';
+import { UserService } from '../user/user.service';
 import { AdoptionPostResolver } from './adoption-post.resolver';
 import { AdoptionPostService } from './adoption-post.service';
 
@@ -21,6 +24,14 @@ import { AdoptionPostService } from './adoption-post.service';
       AdopteeUserRepository,
     ]),
   ],
-  providers: [AdoptionPostResolver, AdoptionPostService, PetService],
+  providers: [
+    AdoptionPostResolver,
+    AdoptionPostService,
+    PetService,
+    UserService,
+    AuthService,
+    JwtService,
+  ],
+  exports: [AdoptionPostService],
 })
 export class AdoptionPostModule {}

--- a/nest_server/src/modules/adoption-post/adoption-post.resolver.ts
+++ b/nest_server/src/modules/adoption-post/adoption-post.resolver.ts
@@ -1,56 +1,53 @@
+import { HttpException, UseGuards } from '@nestjs/common';
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
-import { CreateAdoptionPostArgs } from './dtos/create-adoption-post.dto';
-import { AdoptionPostService } from './adoption-post.service';
-import { AdoptionPost } from 'src/entities/adoption-post.entity';
-import { GetAdoptionPostArgs } from './dtos/get-adoption-post.dto';
-import { AdoptUser } from 'src/entities/adopt-user.entity';
-import { AuthUser } from '../auth/decorators/auth.decorator';
-import { RequestOutput } from '../common/dtos/request-result.dto';
-import { UseGuards } from '@nestjs/common';
 import { GqlAuthGuard } from '../auth/guards/gql-auth-guard';
+import { GetAdoptionPostArgs } from './dtos/get-adoption-post.dto';
+import {
+  CreateAdoptionPostArgs,
+  CreateAdoptionPostOutput,
+} from './dtos/create-adoption-post.dto';
+import { User, UserType } from 'src/entities/user.entity';
+import { AdoptionPost } from 'src/entities/adoption-post.entity';
+import { AdoptionPostService } from './adoption-post.service';
+import { UserService } from '../user/user.service';
+import { AuthUser } from '../auth/decorators/auth.decorator';
 
 @Resolver()
 export class AdoptionPostResolver {
-  constructor(private readonly adoptionPostService: AdoptionPostService) {}
+  constructor(
+    private readonly adoptionPostService: AdoptionPostService,
+    private readonly userService: UserService,
+  ) {}
 
-  @Mutation(() => RequestOutput)
+  @Mutation(() => CreateAdoptionPostOutput)
+  @UseGuards(GqlAuthGuard)
   async createAdoptionPost(
-    // TODO: user 로그인 되면 현재 로그인 되어있는(gql context 할당되어 있는) 유저로 받을 것
-    // TODO: @AuthUser 데코레이터 구현시 대체 해야합니다.
-    @AuthUser() user: AdoptUser,
+    @AuthUser() user: User,
     @Args('postArgs') postArgs: CreateAdoptionPostArgs,
-  ): Promise<RequestOutput> {
-    return await this.adoptionPostService.createAdoptionPost(user, postArgs);
+  ): Promise<CreateAdoptionPostOutput> {
+    if (user && user.userType === UserType.ADOPT) {
+      if (!user.isAvailable) {
+        throw new HttpException('Not available User', 401);
+      }
+      const adoptUser = await this.userService.findAdoptUser(user);
+      if (adoptUser) {
+        return await this.adoptionPostService.createAdoptionPost(
+          adoptUser,
+          postArgs,
+        );
+      }
+    }
   }
 
-  @Query(() => RequestOutput)
-  @UseGuards(GqlAuthGuard)
+  @Query(() => [AdoptionPost])
   async getPosts(
     @Args('getPostsArgs') getPostsArgs: GetAdoptionPostArgs,
-  ): Promise<RequestOutput<AdoptionPost[]>> {
+  ): Promise<AdoptionPost[]> {
     return await this.adoptionPostService.getAdoptionPosts(getPostsArgs);
   }
-}
 
-/**
- * mutation 입력 예제
- * 
-# mutation {
-#   createAdoptionPost(postArgs: {
-#     title: "입양글제목1",
-# 		content: "기래요~?",
-# 		name: "요크셔1",
-# 		breed: "요크셔테리어",
-# 		type: "dog",
-# 		price: 3000000,
-# 		age: 1,
-# 		weight: 5,
-# 		isGenderMale: false,
-# 		vaccinated: false,
-# 		neutered: false,
-# 		characteristic: "잘 뛰어다녀요~!",
-# 		othersInfo: "낮선 사람에게도 순종적입니다!"
-#   }) {
-#     result
-# }
- */
+  @Query(() => AdoptionPost)
+  async getPost(@Args('id') id: number): Promise<AdoptionPost> {
+    return await this.adoptionPostService.getAdoptionPost(id);
+  }
+}

--- a/nest_server/src/modules/adoption-post/adoption-post.service.ts
+++ b/nest_server/src/modules/adoption-post/adoption-post.service.ts
@@ -4,12 +4,11 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Pets } from 'src/entities/pets.entity';
 import { AdoptUser } from 'src/entities/adopt-user.entity';
 import { AdoptionPost } from 'src/entities/adoption-post.entity';
-import { CreateAdoptionPostArgs } from './dtos/create-adoption-post.dto';
-import { GetAdoptionPostArgs } from './dtos/get-adoption-post.dto';
 import {
-  RequestOutput,
-  RequestOutputObj,
-} from '../common/dtos/request-result.dto';
+  CreateAdoptionPostArgs,
+  CreateAdoptionPostOutput,
+} from './dtos/create-adoption-post.dto';
+import { GetAdoptionPostArgs } from './dtos/get-adoption-post.dto';
 
 @Injectable()
 export class AdoptionPostService {
@@ -23,65 +22,46 @@ export class AdoptionPostService {
   async createAdoptionPost(
     user: AdoptUser,
     postArgs: CreateAdoptionPostArgs,
-  ): Promise<RequestOutput> {
-    try {
-      const writter = user; // TODO: @AuthUser 구현시 대체
+  ): Promise<CreateAdoptionPostOutput> {
+    const writter = user;
 
-      if (!writter) {
-        throw new HttpException('invalid User', 401);
-      }
-
-      const pet = this.petsRepository.create({
-        ...postArgs,
-        registrant: writter,
-      });
-      await this.petsRepository.save(pet);
-
-      const post = this.adoptionPostRepository.create({
-        ...postArgs,
-        writter,
-        pet,
-      });
-      await this.adoptionPostRepository.save(post);
-
-      return RequestOutputObj({ id: post.id }, 200);
-    } catch (error) {
-      return RequestOutputObj({ error: error.message }, error.status);
+    if (!writter) {
+      throw new HttpException('invalid User', 401);
     }
+
+    const pet = this.petsRepository.create({
+      ...postArgs,
+      registrant: writter,
+    });
+    await this.petsRepository.save(pet);
+
+    const post = this.adoptionPostRepository.create({
+      ...postArgs,
+      writter,
+      pet,
+    });
+    await this.adoptionPostRepository.save(post);
+
+    return { result: true, id: post.id };
   }
 
-  async findOneAdoptionPost(id: number): Promise<AdoptionPost> {
+  async getAdoptionPost(id: number): Promise<AdoptionPost> {
     return await this.adoptionPostRepository.findOne(id);
   }
 
-  /**
-   * 입양글 리스트 API
-   *
-   * @param args {page = 1, isProfit = boolean | undefined}
-   * @returns AdoptionPost[]
-   */
-  async getAdoptionPosts(
-    args: GetAdoptionPostArgs,
-  ): Promise<RequestOutput<AdoptionPost[]>> {
-    try {
-      const take = 20;
-      const where = {};
+  async getAdoptionPosts(args: GetAdoptionPostArgs): Promise<AdoptionPost[]> {
+    const take = 20;
+    const where = {};
 
-      if (args.isProfit !== undefined) {
-        where['writter'] = { isProfit: args.isProfit };
-      }
-
-      return RequestOutputObj(
-        await this.adoptionPostRepository.find({
-          skip: take * (args.page - 1),
-          take,
-          where,
-          relations: ['writter'],
-        }),
-        200,
-      );
-    } catch (error) {
-      return RequestOutputObj({ error: error.message }, error.statusCode);
+    if (args.isProfit !== undefined) {
+      where['writter'] = { isProfit: args.isProfit };
     }
+
+    return await this.adoptionPostRepository.find({
+      skip: take * (args.page - 1),
+      take,
+      where,
+      relations: ['writter'],
+    });
   }
 }

--- a/nest_server/src/modules/adoption-post/dtos/create-adoption-post.dto.ts
+++ b/nest_server/src/modules/adoption-post/dtos/create-adoption-post.dto.ts
@@ -18,4 +18,7 @@ export class CreateAdoptionPostArgs extends IntersectionType(
 export class CreateAdoptionPostOutput {
   @Field(() => Boolean)
   result: boolean;
+
+  @Field(() => Number)
+  id: number;
 }

--- a/nest_server/src/modules/auth/auth.interface.ts
+++ b/nest_server/src/modules/auth/auth.interface.ts
@@ -1,0 +1,7 @@
+import { UserType } from 'src/entities/user.entity';
+
+export interface Payload {
+  email: string;
+  userType: UserType;
+  isAvailable: boolean;
+}

--- a/nest_server/src/modules/auth/auth.module.ts
+++ b/nest_server/src/modules/auth/auth.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserRepository } from 'src/modules/user/user.repository';
 import { AuthResolver } from './auth.resolver';
 import { AuthService } from './auth.service';
+import { JwtService } from './jwt.service';
 import { JwtStrategy } from './jwt.strategy';
 
 @Module({
@@ -22,7 +23,7 @@ import { JwtStrategy } from './jwt.strategy';
     }),
     TypeOrmModule.forFeature([UserRepository]),
   ],
-  providers: [AuthResolver, AuthService, JwtStrategy],
+  providers: [AuthResolver, AuthService, JwtStrategy, JwtService],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/nest_server/src/modules/auth/auth.service.ts
+++ b/nest_server/src/modules/auth/auth.service.ts
@@ -1,14 +1,15 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserRepository } from 'src/modules/user/user.repository';
+import { JwtService } from './jwt.service';
 import { LoginInput } from './dtos/auth-credentials.dto';
 import * as bcrypt from 'bcrypt';
 import { User } from 'src/entities/user.entity';
-import { JwtService } from '@nestjs/jwt';
 import {
   RequestOutput,
   RequestOutputObj,
 } from '../common/dtos/request-result.dto';
+import { Payload } from './auth.interface';
 
 @Injectable()
 export class AuthService {
@@ -26,7 +27,7 @@ export class AuthService {
 
     if (user && (await bcrypt.compare(password, user.password))) {
       const { userType, isAvailable } = user;
-      const payload = { email, userType, isAvailable };
+      const payload: Payload = { email, userType, isAvailable };
       const accessToken = await this.jwtService.sign(payload);
 
       return RequestOutputObj({ token: accessToken }, 200);

--- a/nest_server/src/modules/auth/decorators/auth.decorator.ts
+++ b/nest_server/src/modules/auth/decorators/auth.decorator.ts
@@ -4,8 +4,9 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 export const AuthUser = createParamDecorator(
   (_: any, context: ExecutionContext) => {
     const gqlContext = GqlExecutionContext.create(context).getContext();
-    if (gqlContext['user']) {
-      return gqlContext['user'];
+
+    if (gqlContext.req?.user) {
+      return gqlContext.req.user;
     }
     return null;
   },

--- a/nest_server/src/modules/auth/guards/gql-auth-guard.ts
+++ b/nest_server/src/modules/auth/guards/gql-auth-guard.ts
@@ -8,7 +8,7 @@ import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class GqlAuthGuard extends AuthGuard('jwt') {
-  handleRequest(err, user, info) {
+  handleRequest(err, user, _info) {
     if (err || !user) {
       throw err || new UnauthorizedException();
     }

--- a/nest_server/src/modules/auth/jwt.service.ts
+++ b/nest_server/src/modules/auth/jwt.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+import { Payload } from './auth.interface';
+
+@Injectable()
+export class JwtService {
+  sign(payload: Payload): string {
+    return jwt.sign(payload, process.env.JWT_SECRET);
+  }
+  verify(token: string) {
+    return jwt.verify(token, process.env.JWT_SECRET);
+  }
+}

--- a/nest_server/src/modules/auth/jwt.strategy.ts
+++ b/nest_server/src/modules/auth/jwt.strategy.ts
@@ -13,7 +13,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
-        (req) => String(req.headers['x-jwt']),
+        (req) => String(req.headers['x-jwt']), // Authorization: Bearer 타입으로 수정해야 함
       ]),
       ignoreExpiration: false,
       secretOrKey: process.env.JWT_SECRET,

--- a/nest_server/src/modules/banner/banner.module.ts
+++ b/nest_server/src/modules/banner/banner.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BannerContent } from 'src/entities/banner-content.entity';
+import { Banner } from 'src/entities/banner.entity';
 import { BannerResolver } from './banner.resolver';
 import { BannerService } from './banner.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Banner, BannerContent])],
   providers: [BannerResolver, BannerService],
 })
 export class BannerModule {}

--- a/nest_server/src/modules/banner/banner.resolver.ts
+++ b/nest_server/src/modules/banner/banner.resolver.ts
@@ -1,4 +1,44 @@
-import { Resolver } from '@nestjs/graphql';
+import { HttpException, UseGuards } from '@nestjs/common';
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql';
+import { BannerContent } from 'src/entities/banner-content.entity';
+import { Banner } from 'src/entities/banner.entity';
+import { User, UserType } from 'src/entities/user.entity';
+import { AuthUser } from '../auth/decorators/auth.decorator';
+import { GqlAuthGuard } from '../auth/guards/gql-auth-guard';
+import { BannerService } from './banner.service';
+import {
+  CreateBannerInput,
+  CreateBannerOutput,
+} from './dtos/create-banner.dto';
 
 @Resolver()
-export class BannerResolver {}
+export class BannerResolver {
+  constructor(private readonly bannerService: BannerService) {}
+
+  @Mutation(() => CreateBannerOutput)
+  // @UseGuards(GqlAuthGuard)
+  async CreateBanner(
+    @AuthUser() user: User,
+    @Args('input') input: CreateBannerInput,
+  ): Promise<CreateBannerOutput> {
+    // if (user && user.userType === UserType.ADMIN) {
+    //   if (!user.isAvailable) {
+    //     throw new HttpException('Not available User', 401);
+    //   }
+    //   return await this.bannerService.createBanner(input);
+    // }
+    // throw new HttpException('Not Found User', 401);
+
+    return await this.bannerService.createBanner(input);
+  }
+
+  @Query(() => BannerContent)
+  async getBannerContent(@Args('id') id: number): Promise<BannerContent> {
+    return await this.bannerService.getBannerContent(id);
+  }
+
+  @Query(() => [Banner])
+  async getBanners(): Promise<Banner[]> {
+    return await this.bannerService.getBanners();
+  }
+}

--- a/nest_server/src/modules/banner/banner.service.ts
+++ b/nest_server/src/modules/banner/banner.service.ts
@@ -1,4 +1,43 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { BannerContent } from 'src/entities/banner-content.entity';
+import { Banner } from 'src/entities/banner.entity';
+import { Repository } from 'typeorm';
+import {
+  CreateBannerInput,
+  CreateBannerOutput,
+} from './dtos/create-banner.dto';
 
 @Injectable()
-export class BannerService {}
+export class BannerService {
+  constructor(
+    @InjectRepository(Banner)
+    private readonly bannerRepository: Repository<Banner>,
+    @InjectRepository(BannerContent)
+    private readonly bannerContentRepository: Repository<BannerContent>,
+  ) {}
+
+  async createBanner(input: CreateBannerInput): Promise<CreateBannerOutput> {
+    const bannerContentEntity = this.bannerContentRepository.create(input);
+    const bannerContent = await this.bannerContentRepository.save(
+      bannerContentEntity,
+    );
+
+    const bannerEntity = this.bannerRepository.create({
+      ...input,
+      content: bannerContent,
+    });
+
+    const banner = await this.bannerRepository.save(bannerEntity);
+
+    return { result: true, id: banner.id };
+  }
+
+  async getBannerContent(id: number): Promise<BannerContent> {
+    return await this.bannerContentRepository.findOne(id);
+  }
+
+  async getBanners(): Promise<Banner[]> {
+    return await this.bannerRepository.find({});
+  }
+}

--- a/nest_server/src/modules/banner/dtos/create-banner.dto.ts
+++ b/nest_server/src/modules/banner/dtos/create-banner.dto.ts
@@ -1,0 +1,24 @@
+import {
+  Field,
+  InputType,
+  IntersectionType,
+  ObjectType,
+  OmitType,
+} from '@nestjs/graphql';
+import { BannerContent } from 'src/entities/banner-content.entity';
+import { Banner } from 'src/entities/banner.entity';
+
+@InputType()
+export class CreateBannerInput extends IntersectionType(
+  OmitType(BannerContent, ['id'] as const),
+  OmitType(Banner, ['id', 'content'] as const),
+) {}
+
+@ObjectType()
+export class CreateBannerOutput {
+  @Field(() => Boolean)
+  result: true;
+
+  @Field(() => Number)
+  id: number;
+}

--- a/nest_server/src/modules/user/user.module.ts
+++ b/nest_server/src/modules/user/user.module.ts
@@ -8,8 +8,14 @@ import { AdoptUserPicture } from '../../entities/adopt-user-picture.entity';
 import { AuthenticateInfo } from '../../entities/authenticate-info.entity';
 import { UserResolver } from './user.resolver';
 import { UserService } from './user.service';
-import { AdopteeUserRepository, AdoptUserRepository, UserRepository } from './user.repository';
+import {
+  AdopteeUserRepository,
+  AdoptUserRepository,
+  UserRepository,
+} from './user.repository';
 import { AuthModule } from '../auth/auth.module';
+import { AuthService } from '../auth/auth.service';
+import { JwtService } from '../auth/jwt.service';
 
 @Module({
   imports: [
@@ -26,9 +32,7 @@ import { AuthModule } from '../auth/auth.module';
     ]),
     AuthModule,
   ],
-  providers: [
-    UserService,
-    UserResolver,
-  ],
+  providers: [UserService, UserResolver, AuthService, JwtService],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/nest_server/src/modules/user/user.service.ts
+++ b/nest_server/src/modules/user/user.service.ts
@@ -30,7 +30,6 @@ export class UserService {
     @InjectRepository(AdoptUserRepository)
     private adoptUserRepository: AdoptUserRepository,
 
-    @Inject(AuthService)
     private authService: AuthService,
   ) {}
 
@@ -158,5 +157,12 @@ export class UserService {
     adoptUser.user = { ...adoptUser.user, ...userInput };
     const updatedUser: AdoptUser = await this.adoptUserRepository.save({...adoptUser, ...adoptInput});
     return updatedUser
+  }
+
+  async findAdoptUser(user: User) {
+    return await this.adoptUserRepository.findOne(user.id);
+  }
+  async findAdopteeUser(user: User) {
+    return await this.adopteeUserRepository.findOne(user.id);
   }
 }


### PR DESCRIPTION
fix :

AdoptUser Entity 에 변동사항이 생겼습니다.
Relation 으로 생성한 primary key 에 userId 가 다른 엔티티에서 save 할때 id 가 db 에 들어가지 않는 현상이 발견되었습니다. (OneToOne 으로 생성한 User 필드)

변경사항은 다음과 같습니다.

  @JoinColumn({ name: 'userId' })
  @Field(() => User, { nullable: true })
  user: User;

  // PK ref User.id
  @PrimaryColumn()
  userId: number;

JoinColumn 에 'userId' 변수명을 지정해주고, userId 필드를 직접 생성하여 PrimaryColumn 으로 지정합니다. JoinColumn 에 명시해 줌으로써, 직접 생성한 필드에 id 가 inject 됩니다.

JwtService 를 provide 하기 위해 별도의 Wrapper Service 를 만들었습니다. 다른 곳에서 UserService 를 사용할 경우 DI 가 꼬이는 문제가 발생했기 때문입니다.

기타 - adoption-post / pet entity 에서 relation 이 적용된 DB 필드명을 지정해주었습니다. (가독성 때문)

feature : 

생성한 Query/Mutation 입니다.
CreateAdoption (Mutation) / getAdoptionPosts / getAdoptionPost
CreateBanner (Mutation) / getBanners / getBannerContent

배너 적용을 위한 테스트 Mutation (DB 에 삽입하기 위함)
CreateBanner Mutations ( PlayGround 에서 한번씩만 실행해주세요 )

mutation {
  CreateBanner(input: {
    title: "배너 1",
    detailContent: "배너 테스트입니다!",
    thumbnailUri: "https://res.cloudinary.com/dyfuiigbw/image/upload/v1642035956/samples/animals/three-dogs.jpg"
  }) {
    result
    id
  }
}

mutation {
  CreateBanner(input: {
    title: "배너 2",
    detailContent: "배너 2 테스트입니다!",
    thumbnailUri: "https://res.cloudinary.com/dyfuiigbw/image/upload/v1642035951/samples/animals/reindeer.jpg"
  }) {
    result
    id
  }
}

mutation { 
  CreateBanner(input: {
    title: "배너 3",
    detailContent: "배너 3 테스트입니다!",
    thumbnailUri: "https://res.cloudinary.com/dyfuiigbw/image/upload/v1642035949/samples/animals/cat.jpg"
  }) {
    result
    id
  }
}