### PR TITLE
API 요청 권한 검증 로직 구현

### DIFF
--- a/nest_server/src/entities/adopt-review-like.entity.ts
+++ b/nest_server/src/entities/adopt-review-like.entity.ts
@@ -16,6 +16,7 @@ export class AdoptionReviewLike extends CoreIdEntity {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'userId' })
+  @Field(() => AdopteeUser, { nullable: true })
   adopteeUser: AdopteeUser;
 
   @Column()
@@ -24,7 +25,6 @@ export class AdoptionReviewLike extends CoreIdEntity {
 
   @ManyToOne(() => AdoptReview, (review) => review.likes, {
     nullable: false,
-    cascade: true,
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'reviewId' })

--- a/nest_server/src/entities/adopt-review-picture.entity.ts
+++ b/nest_server/src/entities/adopt-review-picture.entity.ts
@@ -12,13 +12,13 @@ import { ColumnTextType } from './database-data-type';
 export class AdoptReviewPicture extends CoreIdEntity {
   @ManyToOne(() => AdoptReview, (adoptReview) => adoptReview.pictures, {
     nullable: false,
-    cascade: true,
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'reviewId' })
   @Field(() => AdoptReview, { nullable: true })
   adoptReview: AdoptReview;
 
+  @Column()
   @Field(() => Int, { nullable: true })
   reviewId: number;
 

--- a/nest_server/src/entities/adopt-review.entity.ts
+++ b/nest_server/src/entities/adopt-review.entity.ts
@@ -28,6 +28,7 @@ export class AdoptReview extends CoreEntity {
   @Field(() => AdopteeUser, { nullable: true })
   adopteeUser: AdopteeUser;
 
+  @Column()
   @Field(() => Int, { nullable: true })
   userId: number;
 
@@ -41,6 +42,7 @@ export class AdoptReview extends CoreEntity {
 
   @OneToMany(() => AdoptReviewPicture, (picture) => picture.adoptReview, {
     nullable: true,
+    cascade: true,
     eager: true,
   })
   @Field(() => [AdoptReviewPicture], { nullable: true })
@@ -48,6 +50,7 @@ export class AdoptReview extends CoreEntity {
 
   @OneToMany(() => AdoptionReviewLike, (like) => like.likePost, {
     nullable: true,
+    cascade: true,
     eager: true,
   })
   @Field(() => [AdoptionReviewLike], { nullable: true })
@@ -59,6 +62,7 @@ export class AdoptReview extends CoreEntity {
 
   @OneToMany(() => Comment, (comment) => comment.post, {
     nullable: true,
+    cascade: true,
     eager: true,
   })
   @Field(() => [Comment], { nullable: true })

--- a/nest_server/src/entities/adopt-user.entity.ts
+++ b/nest_server/src/entities/adopt-user.entity.ts
@@ -1,5 +1,5 @@
 import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { Field, InputType, Int, ObjectType } from '@nestjs/graphql';
 import { CoreDateEntity } from 'src/entities/common/core.entity';
 import { User } from './user.entity';
 import { ColumnTextType } from './database-data-type';
@@ -21,6 +21,7 @@ export class AdoptUser extends CoreDateEntity {
 
   // PK ref User.id
   @PrimaryColumn()
+  @Field(() => Int, { nullable: true })
   userId: number;
 
   @Column({ nullable: false, unique: true })

--- a/nest_server/src/modules/adopt-review/adopt-review.repository.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.repository.ts
@@ -11,6 +11,7 @@ import {
 import { Comment } from 'src/entities/comment.entity';
 import { UpdateAdoptReviewCommentInput } from './dtos/update-review.dto';
 import { User } from 'src/entities/user.entity';
+import { AdoptionReviewLikeInput } from './dtos/review-like.dto';
 
 interface CreateReviewInput {
   title: string;
@@ -128,7 +129,8 @@ export class AdoptionReviewLikeRepository extends Repository<AdoptionReviewLike>
     return await this.save(reviewLike);
   }
 
-  async deleteAdoptionReviewLike(reviewId: number, userId: number) {
+  async deleteAdoptionReviewLike(input: AdoptionReviewLikeInput) {
+    const { reviewId, userId } = input;
     const result = await getConnection()
       .createQueryBuilder()
       .delete()

--- a/nest_server/src/modules/adopt-review/adopt-review.resolver.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.resolver.ts
@@ -4,10 +4,7 @@ import { AdoptReview } from '../../entities/adopt-review.entity';
 import { DeleteRequestOutput } from '../common/dtos/request-result.dto';
 import { AdoptReviewService } from './adopt-review.service';
 import { CreateAdoptReviewPictureInput } from './dtos/create-review-picture.dto';
-import {
-  AdoptionReviewLikeInput,
-  AdoptionReviewLikeOutput,
-} from './dtos/review-like.dto';
+import { AdoptionReviewLikeOutput } from './dtos/review-like.dto';
 import { CreateReviewInput } from './dtos/create-review.dto';
 import {
   UpdateAdoptReviewCommentInput,
@@ -47,40 +44,45 @@ export class AdoptReviewResolver {
   @Mutation(() => AdoptReview)
   updateAdoptReview(
     @Args('input') updateAdoptReviewInput: UpdateAdoptReviewInput,
+    @AuthUser() user: User,
   ) {
-    return this.adoptReviewService.updateAdoptReview(updateAdoptReviewInput);
+    return this.adoptReviewService.updateAdoptReview(
+      updateAdoptReviewInput,
+      user,
+    );
   }
 
   @UseGuards(GqlAuthGuard)
   @Mutation(() => DeleteRequestOutput)
-  deleteAdoptReview(@Args('id') id: number) {
-    return this.adoptReviewService.deleteAdoptReview(id);
+  deleteAdoptReview(@Args('id') id: number, @AuthUser() user: User) {
+    return this.adoptReviewService.deleteAdoptReview(id, user);
   }
 
   @UseGuards(GqlAuthGuard)
   @Mutation(() => AdoptReviewPicture)
   createAdoptReviewPicture(
     @Args('input') createAdoptReviewPictureInput: CreateAdoptReviewPictureInput,
+    @AuthUser() user: User,
   ) {
     return this.adoptReviewService.createAdoptReviewPicture(
       createAdoptReviewPictureInput,
+      user,
     );
   }
 
   @UseGuards(GqlAuthGuard)
   @Mutation(() => DeleteRequestOutput)
-  deleteAdoptReviewPicture(@Args('id') id: number) {
-    return this.adoptReviewService.deleteAdoptReviewPicture(id);
+  deleteAdoptReviewPicture(@Args('id') id: number, @AuthUser() user: User) {
+    return this.adoptReviewService.deleteAdoptReviewPicture(id, user);
   }
 
   @UseGuards(GqlAuthGuard)
   @Mutation(() => AdoptionReviewLikeOutput)
   toggleAdoptionReviewLike(
-    @Args('input') adoptionReviewLikeInput: AdoptionReviewLikeInput,
+    @Args('reviewId') reviewId: number,
+    @AuthUser() user: User,
   ) {
-    return this.adoptReviewService.toggleAdoptionReviewLike(
-      adoptionReviewLikeInput,
-    );
+    return this.adoptReviewService.toggleAdoptionReviewLike(reviewId, user);
   }
 
   @Mutation(() => Comment)
@@ -93,11 +95,6 @@ export class AdoptReviewResolver {
       createCommentInput,
       user,
     );
-  }
-
-  @Query(() => Comment)
-  async getOneReviewComment(@Args('id') id: number): Promise<Comment> {
-    return await this.adoptReviewService.getOneReviewComment(id);
   }
 
   @Mutation(() => DeleteRequestOutput)

--- a/nest_server/src/modules/adopt-review/adopt-review.service.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.service.ts
@@ -158,10 +158,10 @@ export class AdoptReviewService {
       throw new UnauthorizedException('해당 요청에 대한 권한이 없습니다.');
     }
     if (this.isAlreadyInLikes(review, user.id)) {
-      await this.adoptionReviewLikeRepository.deleteAdoptionReviewLike(
+      await this.adoptionReviewLikeRepository.deleteAdoptionReviewLike({
         reviewId,
-        user.id,
-      );
+        userId: user.id,
+      });
       resOutput.result = LikeResult.DELETE;
     } else {
       const adopteeUser =

--- a/nest_server/src/modules/adopt-review/adopt-review.service.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.service.ts
@@ -17,11 +17,7 @@ import {
   AdoptReviewPictureRepository,
   AdoptReviewRepository,
 } from './adopt-review.repository';
-import {
-  AdoptionReviewLikeInput,
-  AdoptionReviewLikeOutput,
-  LikeResult,
-} from './dtos/review-like.dto';
+import { AdoptionReviewLikeOutput, LikeResult } from './dtos/review-like.dto';
 import { CreateReviewInput } from './dtos/create-review.dto';
 import {
   UpdateAdoptReviewCommentInput,
@@ -31,7 +27,6 @@ import { CreateAdoptReviewPictureInput } from './dtos/create-review-picture.dto'
 import { CreateCommentInput } from './dtos/create-comment.dto';
 import { User, UserType } from 'src/entities/user.entity';
 import { Comment } from 'src/entities/comment.entity';
-import { UserService } from '../user/user.service';
 
 @Injectable()
 export class AdoptReviewService {
@@ -70,13 +65,29 @@ export class AdoptReviewService {
       createInput,
     );
   }
+  async getReviewWithExceptionHandling(reviewId: number): Promise<AdoptReview> {
+    const review: AdoptReview =
+      await this.adoptReviewRepository.getOneAdoptReviewById(reviewId);
+    if (!review) {
+      throw new BadRequestException('존재하지 않는 게시물입니다.');
+    }
+    return review;
+  }
 
-  async getOneReviewComment(id: number): Promise<Comment> {
-    return await this.adoptReviewCommentRepository.findOneCommentById(id);
+  async getReviewWithVerifyingAuthority(
+    reviewId: number,
+    userId,
+  ): Promise<AdoptReview> {
+    const review = await this.getReviewWithExceptionHandling(reviewId);
+    if (review.userId !== userId) {
+      console.log(review, userId);
+      throw new UnauthorizedException('해당 요청에 대한 권한이 없습니다.');
+    }
+    return review;
   }
 
   async getOneAdoptReview(id: number): Promise<AdoptReview> {
-    return await this.adoptReviewRepository.getOneAdoptReviewById(id);
+    return await this.getReviewWithExceptionHandling(id);
   }
 
   async getAllAdoptReview(): Promise<AdoptReview[]> {
@@ -85,36 +96,44 @@ export class AdoptReviewService {
 
   async updateAdoptReview(
     updateReviewInput: UpdateAdoptReviewInput,
+    user: User,
   ): Promise<AdoptReview> {
     const { id, ...restOfUpdateInput } = updateReviewInput;
-    const review = await this.adoptReviewRepository.getOneAdoptReviewById(id);
+    const review = await this.getReviewWithVerifyingAuthority(id, user.id);
     return await this.adoptReviewRepository.updateAdoptReview(
       review,
       restOfUpdateInput,
     );
   }
 
-  async deleteAdoptReview(id: number): Promise<DeleteRequestOutput> {
+  async deleteAdoptReview(
+    id: number,
+    user: User,
+  ): Promise<DeleteRequestOutput> {
+    await this.getReviewWithVerifyingAuthority(id, user.id);
     const deleteResult: DeleteRequestOutput = {
       result: (await this.adoptReviewRepository.deleteOneUserById(id)).affected,
     };
-    if (deleteResult.result === 0) {
-      throw new BadRequestException(`There is no review with id of ${id}`);
-    }
     return deleteResult;
   }
 
-  async createAdoptReviewPicture(input: CreateAdoptReviewPictureInput) {
+  async createAdoptReviewPicture(
+    input: CreateAdoptReviewPictureInput,
+    user: User,
+  ) {
     const { reviewId, uri } = input;
-    const adoptReview: AdoptReview =
-      await this.adoptReviewRepository.getOneAdoptReviewById(reviewId);
+    const adoptReview: AdoptReview = await this.getReviewWithVerifyingAuthority(
+      reviewId,
+      user.id,
+    );
     return await this.adoptReviewPictureRepository.createAdoptReviewPicture({
       adoptReview,
       uri,
     });
   }
 
-  async deleteAdoptReviewPicture(id: number) {
+  async deleteAdoptReviewPicture(id: number, user: User) {
+    await this.getReviewWithVerifyingAuthority(id, user.id);
     const resOutput: DeleteRequestOutput = {
       result: (
         await this.adoptReviewPictureRepository.deleteAdoptReviewPicture(id)
@@ -128,62 +147,60 @@ export class AdoptReviewService {
   }
 
   async toggleAdoptionReviewLike(
-    input: AdoptionReviewLikeInput,
+    reviewId: number,
+    user: User,
   ): Promise<AdoptionReviewLikeOutput> {
-    const { userId, reviewId } = input;
     const resOutput: AdoptionReviewLikeOutput = {
       result: LikeResult.CREATE,
     };
-    const review = await this.adoptReviewRepository.getOneAdoptReviewById(
-      reviewId,
-    );
-    if (this.isAlreadyInLikes(review, userId)) {
-      await this.adoptionReviewLikeRepository.deleteAdoptionReviewLike(input);
+    const review = await this.getReviewWithExceptionHandling(reviewId);
+    if (user.userType !== UserType.ADOPTEE) {
+      throw new UnauthorizedException('해당 요청에 대한 권한이 없습니다.');
+    }
+    if (this.isAlreadyInLikes(review, user.id)) {
+      await this.adoptionReviewLikeRepository.deleteAdoptionReviewLike(
+        reviewId,
+        user.id,
+      );
       resOutput.result = LikeResult.DELETE;
     } else {
-      const user = await this.adopteeUserRepository.getOneAdopteeUserById(
-        userId,
-      );
+      const adopteeUser =
+        await this.adopteeUserRepository.getOneAdopteeUserById(user.id);
       await this.adoptionReviewLikeRepository.createAdoptionReviewLike(
-        user,
+        adopteeUser,
         review,
       );
     }
     return resOutput;
   }
 
-  async exceptionHandingForGetPost(postId: number) {
-    const post = await this.adoptReviewRepository.getOneAdoptReviewById(postId);
-    if (!post) {
-      throw new BadRequestException('존재하지 않는 게시물입니다.');
+  async getCommentWithExceptionHandling(commentId: number) {
+    const comment = await this.adoptReviewCommentRepository.findOneCommentById(
+      commentId,
+    );
+    if (!comment) {
+      throw new BadRequestException('댓글이 존재하지 않습니다.');
     }
-    return post;
+    return comment;
   }
 
-  async exceptionHandlingForGetParent(parentId: number) {
-    if (parentId) {
-      const parentComment =
-        await this.adoptReviewCommentRepository.findOneCommentById(parentId);
-      if (!parentComment) {
-        throw new BadRequestException('댓글이 존재하지 않습니다.');
-      }
-      return parentComment;
+  async getCommentWithVerifyingAuthority(commentId: number, userId: number) {
+    const comment = await this.getCommentWithExceptionHandling(commentId);
+    if (comment.writerId !== userId) {
+      throw new UnauthorizedException('해당 요청에 대한 권한이 없습니다.');
     }
-    return null;
+    return comment;
   }
 
   async createAdoptReviewComment(
     input: CreateCommentInput,
     user: User,
   ): Promise<Comment> {
-    if (!user) {
-      throw new UnauthorizedException('로그인을 해주세요.');
-    }
     const { parentCommentId, postId, content } = input;
-    const post: AdoptReview = await this.exceptionHandingForGetPost(postId);
-    const parent: Comment = await this.exceptionHandlingForGetParent(
-      parentCommentId,
-    );
+    const post: AdoptReview = await this.getReviewWithExceptionHandling(postId);
+    const parent: Comment = parentCommentId
+      ? await this.getCommentWithExceptionHandling(parentCommentId)
+      : null;
     const { nickname: writerNickname } =
       user.userType === UserType.ADOPTEE
         ? await this.adopteeUserRepository.getOneAdopteeUserById(user.id)
@@ -201,11 +218,7 @@ export class AdoptReviewService {
     user: User,
     id: number,
   ): Promise<DeleteRequestOutput> {
-    const comment: Comment =
-      await this.adoptReviewCommentRepository.findOneCommentById(id);
-    if (comment.writerId !== user.id) {
-      throw new UnauthorizedException('해당 댓글을 삭제할 권한이 없습니다.');
-    }
+    await this.getCommentWithVerifyingAuthority(id, user.id);
     const resOutput: DeleteRequestOutput = {
       result: (
         await this.adoptReviewCommentRepository.deleteAdoptReviewComment(id)
@@ -218,14 +231,13 @@ export class AdoptReviewService {
     updateCommentInput: UpdateAdoptReviewCommentInput,
     user: User,
   ) {
-    const comment: Comment =
-      await this.adoptReviewCommentRepository.findOneCommentById(
-        updateCommentInput.id,
-      );
-    if (comment.writerId !== user.id) {
-      throw new UnauthorizedException('해당 댓글을 갱신할 권한이 없습니다.');
-    }
+    const { id: commentId } = updateCommentInput;
+    const comment: Comment = await this.getCommentWithVerifyingAuthority(
+      commentId,
+      user.id,
+    );
     return await this.adoptReviewCommentRepository.updateAdoptReviewComment(
+      comment,
       updateCommentInput,
     );
   }

--- a/nest_server/src/modules/adopt-review/dtos/create-review-picture.dto.ts
+++ b/nest_server/src/modules/adopt-review/dtos/create-review-picture.dto.ts
@@ -1,9 +1,9 @@
-import { Field, InputType } from "@nestjs/graphql";
+import { Field, InputType } from '@nestjs/graphql';
 
 @InputType()
 export class CreateAdoptReviewPictureInput {
   @Field(() => Number, {
-    description: '사진을 업로드 할 리뷰 게시물의 id'
+    description: '사진을 업로드 할 리뷰 게시물의 id',
   })
   reviewId: number;
 

--- a/nest_server/src/modules/adopt-review/dtos/review-like.dto.ts
+++ b/nest_server/src/modules/adopt-review/dtos/review-like.dto.ts
@@ -23,3 +23,8 @@ export class AdoptionReviewLikeOutput {
   @Field(() => LikeResult)
   result: LikeResult;
 }
+
+export class AdoptionReviewLikeInput {
+  userId: number;
+  reviewId: number;
+}

--- a/nest_server/src/modules/adopt-review/dtos/review-like.dto.ts
+++ b/nest_server/src/modules/adopt-review/dtos/review-like.dto.ts
@@ -1,30 +1,8 @@
-import {
-  Field,
-  InputType,
-  ObjectType,
-  registerEnumType,
-} from '@nestjs/graphql';
+import { Field, ObjectType, registerEnumType } from '@nestjs/graphql';
 
 export enum LikeResult {
   CREATE,
   DELETE,
-}
-
-@InputType()
-export class AdoptionReviewLikeInput {
-  @Field(() => Number, {
-    description: `
-    The ID of the AdopteeUser who clicked like.
-    `,
-  })
-  userId: number;
-
-  @Field(() => Number, {
-    description: `
-    The ID of the AdoptReview where the likes will be recorded
-    `,
-  })
-  reviewId: number;
 }
 
 registerEnumType(LikeResult, {

--- a/nest_server/src/modules/user/user.repository.ts
+++ b/nest_server/src/modules/user/user.repository.ts
@@ -8,6 +8,10 @@ import {
   CreateAccountAdoptUserInput,
   CreateAccountUserInput,
 } from './dtos/create-account.dto';
+import {
+  UpdateAdopteeUserInput,
+  UpdateAdoptUserInput,
+} from './dtos/update-user.dto';
 
 @EntityRepository(User)
 export class UserRepository extends Repository<User> {
@@ -66,6 +70,18 @@ export class AdopteeUserRepository extends Repository<AdopteeUser> {
     const adopteeUser = await this.findOne({ nickname });
     return adopteeUser;
   }
+
+  async updateAdopteeUser(
+    adopteeUser: AdopteeUser,
+    input: UpdateAdopteeUserInput,
+  ) {
+    const { user: userInput, ...adopteeInput } = input;
+    adopteeUser.user = { ...adopteeUser.user, ...userInput };
+    return await this.save({
+      ...adopteeUser,
+      ...adopteeInput,
+    });
+  }
 }
 
 @EntityRepository(AdoptUser)
@@ -83,10 +99,6 @@ export class AdoptUserRepository extends Repository<AdoptUser> {
       .leftJoinAndSelect('adoptUser.user', 'user')
       .where('adoptUser.userId = :id', { id })
       .getOne();
-
-    if (!user) {
-      throw new BadRequestException(`The user with (id:${id}) isn't AdoptUser`);
-    }
     return user;
   }
 
@@ -100,5 +112,14 @@ export class AdoptUserRepository extends Repository<AdoptUser> {
   async findOneAdoptUserByNickname(nickname: string): Promise<AdoptUser> {
     const adoptUser = await this.findOne({ nickname });
     return adoptUser;
+  }
+
+  async updateAdoptUser(adoptUser: AdoptUser, input: UpdateAdoptUserInput) {
+    const { user: userInput, ...adoptInput } = input;
+    adoptUser.user = { ...adoptUser.user, ...userInput };
+    return await this.save({
+      ...adoptUser,
+      ...adoptInput,
+    });
   }
 }

--- a/nest_server/src/modules/user/user.resolver.ts
+++ b/nest_server/src/modules/user/user.resolver.ts
@@ -20,6 +20,7 @@ import {
 } from './dtos/check-duplicate-field.dto';
 import { UseGuards } from '@nestjs/common';
 import { GqlAuthGuard } from '../auth/guards/gql-auth-guard';
+import { AuthUser } from '../auth/decorators/auth.decorator';
 
 @Resolver(() => User)
 export class UserResolver {
@@ -57,23 +58,28 @@ export class UserResolver {
     return this.userService.getAllAdoptUser();
   }
 
+  @UseGuards(GqlAuthGuard)
   @Mutation(() => DeleteRequestOutput)
-  deleteOneUser(@Args('id') id: number) {
-    return this.userService.deleteOneUser(id);
+  deleteOneUser(@Args('id') id: number, @AuthUser() user: User) {
+    return this.userService.deleteOneUser(id, user);
   }
 
   @UseGuards(GqlAuthGuard)
   @Mutation(() => AdopteeUser)
   updateAdopteeUser(
     @Args('input') updateAdopteeUserInput: UpdateAdopteeUserInput,
+    @AuthUser() user: User,
   ) {
-    return this.userService.updateAdopteeUser(updateAdopteeUserInput);
+    return this.userService.updateAdopteeUser(updateAdopteeUserInput, user);
   }
 
   @UseGuards(GqlAuthGuard)
   @Mutation(() => AdoptUser)
-  updateAdoptUser(@Args('input') updateAdoptUserInput: UpdateAdoptUserInput) {
-    return this.userService.updateAdoptUser(updateAdoptUserInput);
+  updateAdoptUser(
+    @Args('input') updateAdoptUserInput: UpdateAdoptUserInput,
+    @AuthUser() user: User,
+  ) {
+    return this.userService.updateAdoptUser(updateAdoptUserInput, user);
   }
 
   @Mutation(() => CreateAccountOutput)

--- a/nest_server/src/modules/user/user.service.ts
+++ b/nest_server/src/modules/user/user.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User, UserType } from 'src/entities/user.entity';
 import {
@@ -130,8 +134,48 @@ export class UserService {
     return { token };
   }
 
+  async getAdopteeUserWithExceptionHandling(id: number): Promise<AdopteeUser> {
+    const adopteeUser = await this.adopteeUserRepository.getOneAdopteeUserById(
+      id,
+    );
+    if (!adopteeUser) {
+      throw new BadRequestException(`id:${id}인 개인유저는 존재하지 않습니다.`);
+    }
+    return adopteeUser;
+  }
+
+  async getAdoptUserWithExceptionHandling(id: number): Promise<AdoptUser> {
+    const adoptUser = await this.adoptUserRepository.getOneAdoptUserById(id);
+    if (!adoptUser) {
+      throw new BadRequestException(`id:${id}인 업체유저는 존재하지 않습니다.`);
+    }
+    return adoptUser;
+  }
+
+  async getAdopteeUserWithVerifyingAuthority(
+    targetId: number,
+    user: User,
+  ): Promise<AdopteeUser> {
+    const targetUser = await this.getAdopteeUserWithExceptionHandling(targetId);
+    if (targetUser.userId !== user.id) {
+      throw new UnauthorizedException('해당 요청에 대한 권한이 없습니다.');
+    }
+    return targetUser;
+  }
+
+  async getAdoptUserWithVerifyingAuthority(
+    targetId: number,
+    user: User,
+  ): Promise<AdoptUser> {
+    const targetUser = await this.getAdoptUserWithExceptionHandling(targetId);
+    if (targetUser.userId !== user.id) {
+      throw new UnauthorizedException('해당 요청에 대한 권한이 없습니다.');
+    }
+    return targetUser;
+  }
+
   async getOneAdopteeUser(id: number): Promise<AdopteeUser> {
-    return await this.adopteeUserRepository.getOneAdopteeUserById(id);
+    return await this.getAdopteeUserWithExceptionHandling(id);
   }
 
   async getAllAdopteeUser(): Promise<AdopteeUser[]> {
@@ -139,53 +183,64 @@ export class UserService {
   }
 
   async getOneAdoptUser(id: number): Promise<AdoptUser> {
-    return await this.adoptUserRepository.getOneAdoptUserById(id);
+    return await this.getAdoptUserWithExceptionHandling(id);
   }
 
   async getAllAdoptUser(): Promise<AdoptUser[]> {
     return await this.adoptUserRepository.getAllAdoptUser();
   }
 
-  async deleteOneUser(id: number) {
+  async deleteOneUser(id: number, user: User) {
+    user.userType === UserType.ADOPTEE
+      ? await this.getAdopteeUserWithVerifyingAuthority(id, user)
+      : await this.getAdoptUserWithVerifyingAuthority(id, user);
     const deleteResult: DeleteRequestOutput = {
       result: (await this.userRepository.deleteOneUserById(id)).affected,
     };
-    if (deleteResult.result === 0) {
-      throw new BadRequestException(`There is no user with id of ${id}`);
-    }
     return deleteResult;
   }
 
-  async updateAdopteeUser(updateInput: UpdateAdopteeUserInput) {
-    const { id, user: userInput, ...adopteeInput } = updateInput;
+  async updateAdopteeUser(updateInput: UpdateAdopteeUserInput, user: User) {
+    const { id } = updateInput;
     const adopteeUser: AdopteeUser =
-      await this.adopteeUserRepository.getOneAdopteeUserById(id);
+      await this.getAdopteeUserWithVerifyingAuthority(id, user);
 
-    if (userInput?.password) {
-      userInput.password = await this.hashingPassword(userInput.password);
+    if (updateInput.user?.password) {
+      updateInput.user.password = await this.hashingPassword(
+        updateInput.user.password,
+      );
     }
-    adopteeUser.user = { ...adopteeUser.user, ...userInput };
-    const updatedUser: AdopteeUser = await this.adopteeUserRepository.save({
-      ...adopteeUser,
-      ...adopteeInput,
-    });
-    return updatedUser;
+    if (
+      updateInput?.nickname &&
+      (await this.checkDuplicateNickname(updateInput?.nickname))
+    ) {
+      throw new BadRequestException('이미 존재하는 닉네임입니다.');
+    }
+    return this.adopteeUserRepository.updateAdopteeUser(
+      adopteeUser,
+      updateInput,
+    );
   }
 
-  async updateAdoptUser(updateInput: UpdateAdoptUserInput) {
-    const { id, user: userInput, ...adoptInput } = updateInput;
-    const adoptUser: AdoptUser =
-      await this.adoptUserRepository.getOneAdoptUserById(id);
+  async updateAdoptUser(updateInput: UpdateAdoptUserInput, user: User) {
+    const { id } = updateInput;
+    const adoptUser: AdoptUser = await this.getAdoptUserWithVerifyingAuthority(
+      id,
+      user,
+    );
 
-    if (userInput?.password) {
-      userInput.password = await this.hashingPassword(userInput.password);
+    if (updateInput.user?.password) {
+      updateInput.user.password = await this.hashingPassword(
+        updateInput.user.password,
+      );
     }
-    adoptUser.user = { ...adoptUser.user, ...userInput };
-    const updatedUser: AdoptUser = await this.adoptUserRepository.save({
-      ...adoptUser,
-      ...adoptInput,
-    });
-    return updatedUser;
+    if (
+      updateInput?.nickname &&
+      (await this.checkDuplicateNickname(updateInput?.nickname))
+    ) {
+      throw new BadRequestException('이미 존재하는 닉네임입니다.');
+    }
+    return this.adoptUserRepository.updateAdoptUser(adoptUser, updateInput);
   }
 
   async findAdoptUser(user: User) {


### PR DESCRIPTION
resolved: #22 

- 권한 검증 또한 예외 처리의 범주 안에 속하므로, 추후에 예외 처리를 위한 클래스를 만들어 하나의 클래스에서 여러 예외 처리를 담당하도록 역할을 분리할 예정.
- 유저 API의 경우, 예외 처리와 권한 검증 로직을 유저의 타입 별로 구현.
유저 타입 별로 로직을 구성하다보니 중복되는 코드가 많음.
이 또한 다형성을 통해 개선할 예정.