### PR TITLE
인증업체 조회 - 페이지네이션 구현

### DIFF
--- a/nest_server/src/modules/user/dtos/get-adopt-users.dto.ts
+++ b/nest_server/src/modules/user/dtos/get-adopt-users.dto.ts
@@ -1,0 +1,7 @@
+import { Field, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class GetAdoptUsersArgs {
+  @Field(() => Number, { nullable: true, defaultValue: 1 })
+  page: number;
+}

--- a/nest_server/src/modules/user/user.repository.ts
+++ b/nest_server/src/modules/user/user.repository.ts
@@ -8,6 +8,7 @@ import {
   CreateAccountAdoptUserInput,
   CreateAccountUserInput,
 } from './dtos/create-account.dto';
+import { GetAdoptUsersArgs } from './dtos/get-adopt-users.dto';
 import {
   UpdateAdopteeUserInput,
   UpdateAdoptUserInput,
@@ -102,11 +103,18 @@ export class AdoptUserRepository extends Repository<AdoptUser> {
     return user;
   }
 
-  async getAllAdoptUser(): Promise<AdoptUser[]> {
-    const allUsers = await this.createQueryBuilder('adoptUser')
+  async getAuthenticatedAdoptUsers(
+    getAdoptUsersArgs: GetAdoptUsersArgs,
+  ): Promise<AdoptUser[]> {
+    const { page } = getAdoptUsersArgs;
+    const users = await this.createQueryBuilder('adoptUser')
       .leftJoinAndSelect('adoptUser.user', 'user')
+      .where('adoptUser.isAuthenticated = true')
+      .skip(10 * (page - 1))
+      .take(10)
+      .orderBy('adoptUser.userId', 'DESC')
       .getMany();
-    return allUsers;
+    return users;
   }
 
   async findOneAdoptUserByNickname(nickname: string): Promise<AdoptUser> {

--- a/nest_server/src/modules/user/user.resolver.ts
+++ b/nest_server/src/modules/user/user.resolver.ts
@@ -21,6 +21,7 @@ import {
 import { UseGuards } from '@nestjs/common';
 import { GqlAuthGuard } from '../auth/guards/gql-auth-guard';
 import { AuthUser } from '../auth/decorators/auth.decorator';
+import { GetAdoptUsersArgs } from './dtos/get-adopt-users.dto';
 
 @Resolver(() => User)
 export class UserResolver {
@@ -54,8 +55,10 @@ export class UserResolver {
   }
 
   @Query(() => [AdoptUser])
-  getAllAdoptUser() {
-    return this.userService.getAllAdoptUser();
+  getAuthenticatedAdoptUsers(
+    @Args('getAdoptUsersArgs') getAdoptUsersArgs: GetAdoptUsersArgs,
+  ) {
+    return this.userService.getAuthenticatedAdoptUsers(getAdoptUsersArgs);
   }
 
   @UseGuards(GqlAuthGuard)

--- a/nest_server/src/modules/user/user.service.ts
+++ b/nest_server/src/modules/user/user.service.ts
@@ -29,6 +29,7 @@ import {
   CheckDuplicateFieldInput,
   CheckDuplicateFieldOutput,
 } from './dtos/check-duplicate-field.dto';
+import { GetAdoptUsersArgs } from './dtos/get-adopt-users.dto';
 
 @Injectable()
 export class UserService {
@@ -186,8 +187,12 @@ export class UserService {
     return await this.getAdoptUserWithExceptionHandling(id);
   }
 
-  async getAllAdoptUser(): Promise<AdoptUser[]> {
-    return await this.adoptUserRepository.getAllAdoptUser();
+  async getAuthenticatedAdoptUsers(
+    getAdoptUsersArgs: GetAdoptUsersArgs,
+  ): Promise<AdoptUser[]> {
+    return await this.adoptUserRepository.getAuthenticatedAdoptUsers(
+      getAdoptUsersArgs,
+    );
   }
 
   async deleteOneUser(id: number, user: User) {


### PR DESCRIPTION
resolved: #62 

- `getAllAdoptUser` → `getAuthenticatedAdoptUser` 로 메서드 변경 및 통일.
- 인자 값으로 page를 받되, 이후 필터링과 같은 확장성을 고려하여 Dto 형식으로 넘겨 받는다.
- 페이지 당 10 rows 설정, userId 기준 역순으로 정렬 (최신 등록 업체가 먼저 렌더링)