### PR TITLE
입양리뷰 조회 - 페이지네이션 구현

### DIFF
--- a/nest_server/src/modules/adopt-review/adopt-review.repository.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.repository.ts
@@ -12,6 +12,7 @@ import { Comment } from 'src/entities/comment.entity';
 import { UpdateAdoptReviewCommentInput } from './dtos/update-review.dto';
 import { User } from 'src/entities/user.entity';
 import { AdoptionReviewLikeInput } from './dtos/review-like.dto';
+import { GetAdoptReviewsArgs } from './dtos/get-adopt-reviews.dto';
 
 interface CreateReviewInput {
   title: string;
@@ -62,8 +63,11 @@ export class AdoptReviewRepository extends Repository<AdoptReview> {
     return review;
   }
 
-  async getAllAdoptReview(): Promise<AdoptReview[]> {
-    const allReviews = await this.createQueryBuilder('review')
+  async getAdoptReviews(
+    getAdoptReviewsArgs: GetAdoptReviewsArgs,
+  ): Promise<AdoptReview[]> {
+    const { page } = getAdoptReviewsArgs;
+    const reviews = await this.createQueryBuilder('review')
       .leftJoinAndSelect('review.adopteeUser', 'adopteeUser')
       .leftJoinAndSelect('adopteeUser.user', 'user')
       .leftJoinAndSelect('review.pictures', 'pictures')
@@ -73,8 +77,11 @@ export class AdoptReviewRepository extends Repository<AdoptReview> {
       .leftJoinAndSelect('comment.parent', 'parent')
       .leftJoinAndSelect('comment.child', 'child')
       .where('comment.parentId IS NULL')
+      .skip(6 * (page - 1))
+      .take(6)
+      .orderBy('review.id', 'DESC')
       .getMany();
-    return allReviews;
+    return reviews;
   }
 
   async updateAdoptReview(

--- a/nest_server/src/modules/adopt-review/adopt-review.resolver.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.resolver.ts
@@ -16,6 +16,7 @@ import { UseGuards } from '@nestjs/common';
 import { GqlAuthGuard } from '../auth/guards/gql-auth-guard';
 import { AuthUser } from '../auth/decorators/auth.decorator';
 import { User } from 'src/entities/user.entity';
+import { GetAdoptReviewsArgs } from './dtos/get-adopt-reviews.dto';
 
 @Resolver()
 export class AdoptReviewResolver {
@@ -36,8 +37,10 @@ export class AdoptReviewResolver {
   }
 
   @Query(() => [AdoptReview])
-  getAllAdoptReview() {
-    return this.adoptReviewService.getAllAdoptReview();
+  getAdoptReviews(
+    @Args('getAdoptReviewsArgs') getAdoptReviewsArgs: GetAdoptReviewsArgs,
+  ) {
+    return this.adoptReviewService.getAdoptReviews(getAdoptReviewsArgs);
   }
 
   @UseGuards(GqlAuthGuard)

--- a/nest_server/src/modules/adopt-review/adopt-review.service.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.service.ts
@@ -27,6 +27,7 @@ import { CreateAdoptReviewPictureInput } from './dtos/create-review-picture.dto'
 import { CreateCommentInput } from './dtos/create-comment.dto';
 import { User, UserType } from 'src/entities/user.entity';
 import { Comment } from 'src/entities/comment.entity';
+import { GetAdoptReviewsArgs } from './dtos/get-adopt-reviews.dto';
 
 @Injectable()
 export class AdoptReviewService {
@@ -90,8 +91,12 @@ export class AdoptReviewService {
     return await this.getReviewWithCheckingNotFound(id);
   }
 
-  async getAllAdoptReview(): Promise<AdoptReview[]> {
-    return await this.adoptReviewRepository.getAllAdoptReview();
+  async getAdoptReviews(
+    getAdoptReviewsArgs: GetAdoptReviewsArgs,
+  ): Promise<AdoptReview[]> {
+    return await this.adoptReviewRepository.getAdoptReviews(
+      getAdoptReviewsArgs,
+    );
   }
 
   async updateAdoptReview(

--- a/nest_server/src/modules/adopt-review/dtos/get-adopt-reviews.dto.ts
+++ b/nest_server/src/modules/adopt-review/dtos/get-adopt-reviews.dto.ts
@@ -1,0 +1,7 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+
+@InputType()
+export class GetAdoptReviewsArgs {
+  @Field(() => Int, { nullable: true, defaultValue: 1 })
+  page: number;
+}


### PR DESCRIPTION
resolved: #62  

- `getAllAdoptReview`→ `getAdoptReviews`로 메서드 변경 및 통일.
- 인자 값으로 page를 받되, 이후 필터링과 같은 확장성을 고려하여 Dto 형식으로 넘겨 받는다.
- 페이지 당 6 Rows 설정, reviewId 기준 역순으로 정렬 (최신 리뷰가 먼저 렌더링)