### PR TITLE
회원가입 프로세스 리팩터링

### DIFF
--- a/nest_server/src/modules/adopt-review/adopt-review.repository.ts
+++ b/nest_server/src/modules/adopt-review/adopt-review.repository.ts
@@ -43,7 +43,7 @@ export class AdoptReviewRepository extends Repository<AdoptReview> {
     adopteeUser: AdopteeUser,
     createInput: CreateReviewInput,
   ): Promise<AdoptReview> {
-    const adoptReview = await this.create({ adopteeUser, ...createInput });
+    const adoptReview = this.create({ adopteeUser, ...createInput });
     return await this.save(adoptReview);
   }
 
@@ -108,12 +108,12 @@ export class AdoptReviewPictureRepository extends Repository<AdoptReviewPicture>
   async createAdoptReviewPicture(
     input: CreatePictureInput,
   ): Promise<AdoptReviewPicture> {
-    const picture = await this.create({ ...input });
+    const picture = this.create({ ...input });
     return await this.save(picture);
   }
 
   async deleteAdoptReviewPicture(id: number): Promise<DeleteResult> {
-    const result = getConnection()
+    const result = await getConnection()
       .createQueryBuilder()
       .delete()
       .from(AdoptReviewPicture)
@@ -129,7 +129,7 @@ export class AdoptionReviewLikeRepository extends Repository<AdoptionReviewLike>
     adopteeUser: AdopteeUser,
     likePost: AdoptReview,
   ) {
-    const reviewLike = await this.create({
+    const reviewLike = this.create({
       adopteeUser,
       likePost,
     });
@@ -152,16 +152,16 @@ export class AdoptionReviewLikeRepository extends Repository<AdoptionReviewLike>
 @EntityRepository(Comment)
 export class AdoptReviewCommentRepository extends Repository<Comment> {
   async findOneCommentById(id: number) {
-    return this.findOne({ id }, { relations: ['parent', 'child'] });
+    return await this.findOne({ id }, { relations: ['parent', 'child'] });
   }
 
   async createAdoptReviewComment(createInput: CreateCommentArgs) {
     const comment = this.create(createInput);
-    return this.save(comment);
+    return await this.save(comment);
   }
 
   async deleteAdoptReviewComment(id: number): Promise<DeleteResult> {
-    const result = getConnection()
+    const result = await getConnection()
       .createQueryBuilder()
       .delete()
       .from(Comment)
@@ -176,6 +176,6 @@ export class AdoptReviewCommentRepository extends Repository<Comment> {
   ): Promise<Comment> {
     const { content } = input;
     const changedComment = { ...comment, content };
-    return this.save(changedComment);
+    return await this.save(changedComment);
   }
 }

--- a/nest_server/src/modules/user/dtos/create-account.dto.ts
+++ b/nest_server/src/modules/user/dtos/create-account.dto.ts
@@ -11,6 +11,10 @@ import { AdopteeUser } from '../../../entities/adoptee-user.entity';
 import { AdoptUser } from '../../../entities/adopt-user.entity';
 import { User, UserType } from '../../../entities/user.entity';
 
+export interface LoginInput {
+  email: string;
+  password: string;
+}
 export interface CreateAccountUserInput {
   email: string;
   nickname?: string;

--- a/nest_server/src/modules/user/user.repository.ts
+++ b/nest_server/src/modules/user/user.repository.ts
@@ -20,8 +20,8 @@ export class UserRepository extends Repository<User> {
     return await this.findOne({ email });
   }
 
-  async createUser(createAccountInput: CreateAccountUserInput): Promise<User> {
-    return await this.create({ ...createAccountInput });
+  createUser(createAccountInput: CreateAccountUserInput): User {
+    return this.create({ ...createAccountInput });
   }
 
   async deleteOneUserById(id: number) {
@@ -41,7 +41,7 @@ export class AdopteeUserRepository extends Repository<AdopteeUser> {
     createAccountInput: CreateAccountAdopteeUserInput,
     user: User,
   ): Promise<AdopteeUser> {
-    const adopteeUser = await this.create({ user, ...createAccountInput });
+    const adopteeUser = this.create({ user, ...createAccountInput });
     return await this.save(adopteeUser);
   }
 
@@ -90,7 +90,7 @@ export class AdoptUserRepository extends Repository<AdoptUser> {
     createAccountInput: CreateAccountAdoptUserInput,
     user: User,
   ): Promise<AdoptUser> {
-    const adoptUser = await this.create({ user, ...createAccountInput });
+    const adoptUser = this.create({ user, ...createAccountInput });
     return await this.save(adoptUser);
   }
 

--- a/nest_server/src/modules/user/user.repository.ts
+++ b/nest_server/src/modules/user/user.repository.ts
@@ -21,8 +21,7 @@ export class UserRepository extends Repository<User> {
   }
 
   async createUser(createAccountInput: CreateAccountUserInput): Promise<User> {
-    const user = await this.create({ ...createAccountInput });
-    return await this.save(user);
+    return await this.create({ ...createAccountInput });
   }
 
   async deleteOneUserById(id: number) {
@@ -38,12 +37,12 @@ export class UserRepository extends Repository<User> {
 
 @EntityRepository(AdopteeUser)
 export class AdopteeUserRepository extends Repository<AdopteeUser> {
-  async createAdopteeUser(
+  async createAndSaveAdopteeUser(
     createAccountInput: CreateAccountAdopteeUserInput,
     user: User,
-  ): Promise<void> {
-    const adopteeUser = this.create({ user, ...createAccountInput });
-    await this.save(adopteeUser);
+  ): Promise<AdopteeUser> {
+    const adopteeUser = await this.create({ user, ...createAccountInput });
+    return await this.save(adopteeUser);
   }
 
   async getOneAdopteeUserById(id: number): Promise<AdopteeUser> {
@@ -87,12 +86,12 @@ export class AdopteeUserRepository extends Repository<AdopteeUser> {
 
 @EntityRepository(AdoptUser)
 export class AdoptUserRepository extends Repository<AdoptUser> {
-  async createAdoptUser(
+  async createAndSaveAdoptUser(
     createAccountInput: CreateAccountAdoptUserInput,
     user: User,
-  ): Promise<void> {
-    const adoptUser = this.create({ user, ...createAccountInput });
-    await this.save(adoptUser);
+  ): Promise<AdoptUser> {
+    const adoptUser = await this.create({ user, ...createAccountInput });
+    return await this.save(adoptUser);
   }
 
   async getOneAdoptUserById(id: number): Promise<AdoptUser> {

--- a/nest_server/src/modules/user/user.service.ts
+++ b/nest_server/src/modules/user/user.service.ts
@@ -57,7 +57,7 @@ export class UserService {
   ): Promise<User> {
     const { email, nickname, password, userType } = createAccountInput;
     await this.exceptionHandlingForDuplicateField({ email, nickname });
-    const user = await this.userRepository.createUser({
+    const user = this.userRepository.createUser({
       email,
       password: await this.hashingPassword(password),
       userType,

--- a/nest_server/src/modules/user/user.service.ts
+++ b/nest_server/src/modules/user/user.service.ts
@@ -10,6 +10,7 @@ import {
   CreateAccountAdoptUserInput,
   CreateAccountOutput,
   CreateAccountUserInput,
+  LoginInput,
 } from './dtos/create-account.dto';
 import {
   AdopteeUserRepository,
@@ -46,6 +47,49 @@ export class UserService {
     private readonly authService: AuthService,
   ) {}
 
+  async hashingPassword(password: string) {
+    const salt = await bcrypt.genSalt();
+    return await bcrypt.hash(password, salt);
+  }
+
+  async createUserAccount(
+    createAccountInput: CreateAccountUserInput,
+  ): Promise<User> {
+    const { email, nickname, password, userType } = createAccountInput;
+    await this.exceptionHandlingForDuplicateField({ email, nickname });
+    const user = await this.userRepository.createUser({
+      email,
+      password: await this.hashingPassword(password),
+      userType,
+    });
+    return user;
+  }
+
+  async exceptionHandlingForDuplicateField(
+    checkFieldInput: CheckDuplicateFieldInput,
+  ) {
+    const resultOfCheckDup = await this.checkDuplicateField(checkFieldInput);
+    if (resultOfCheckDup.result) {
+      throw new BadRequestException('Please do a duplicate test.');
+    }
+  }
+
+  async checkDuplicateField(
+    checkFieldInput: CheckDuplicateFieldInput,
+  ): Promise<CheckDuplicateFieldOutput> {
+    const { email, nickname } = checkFieldInput;
+    const resOutput: CheckDuplicateFieldOutput = {
+      result: false,
+    };
+    if (email) {
+      resOutput.result = await this.checkDuplicateEmail(email);
+    }
+    if (nickname && !resOutput.result) {
+      resOutput.result = await this.checkDuplicateNickname(nickname);
+    }
+    return resOutput;
+  }
+
   async checkDuplicateEmail(email: string): Promise<boolean> {
     const isDup: boolean = (await this.userRepository.findOneByEmail(email))
       ? true
@@ -62,77 +106,50 @@ export class UserService {
     return isDup;
   }
 
-  async checkDuplicateField(
-    checkFieldInput: CheckDuplicateFieldInput,
-  ): Promise<CheckDuplicateFieldOutput> {
-    const { email, nickname } = checkFieldInput;
-    const resOutput: CheckDuplicateFieldOutput = {
-      result: false,
-    };
-    if (email) resOutput.result = await this.checkDuplicateEmail(email);
-    if (nickname)
-      resOutput.result = await this.checkDuplicateNickname(nickname);
-    return resOutput;
-  }
-
-  async hashingPassword(password: string) {
-    const salt = await bcrypt.genSalt();
-    return await bcrypt.hash(password, salt);
-  }
-
-  async createUserAccount(
-    createAccountInput: CreateAccountUserInput,
-  ): Promise<User> {
-    const { email, nickname, password, userType } = createAccountInput;
-    const resultOfCheckDup = await this.checkDuplicateField({
-      email,
-      nickname,
-    });
-    if (resultOfCheckDup.result) {
-      throw new BadRequestException('Please do a duplicate test.');
-    }
-
-    const hashedPassword = await this.hashingPassword(password);
-    const createUserInput: CreateAccountUserInput = {
-      email,
-      password: hashedPassword,
-      userType,
-    };
-
-    return await this.userRepository.createUser(createUserInput);
-  }
-
   async createAdopteeAccount(
     createAccountInput: CreateAccountAdopteeUserInput,
   ): Promise<CreateAccountOutput> {
-    const createAccountUserInput: CreateAccountUserInput = {
+    const user: User = await this.createAndGetUser({
       ...createAccountInput,
       userType: UserType.ADOPTEE,
-    };
-    const user: User = await this.createUserAccount(createAccountUserInput);
-    await this.adopteeUserRepository.createAdopteeUser(
+    });
+    await this.adopteeUserRepository.createAndSaveAdopteeUser(
       createAccountInput,
       user,
     );
     const { email, password } = createAccountInput;
-    const token = (await this.authService.login({ email, password }))?.result
-      ?.token;
+    const token = await this.getAccessToken({ email, password });
     return { token };
   }
 
   async createAdoptAccount(
     createAccountInput: CreateAccountAdoptUserInput,
   ): Promise<CreateAccountOutput> {
-    const createAccountUserInput: CreateAccountUserInput = {
+    const user: User = await this.createAndGetUser({
       ...createAccountInput,
       userType: UserType.ADOPT,
-    };
-    const user: User = await this.createUserAccount(createAccountUserInput);
-    await this.adoptUserRepository.createAdoptUser(createAccountInput, user);
+    });
+    await this.adoptUserRepository.createAndSaveAdoptUser(
+      createAccountInput,
+      user,
+    );
     const { email, password } = createAccountInput;
-    const token = (await this.authService.login({ email, password }))?.result
-      ?.token;
+    const token = await this.getAccessToken({ email, password });
     return { token };
+  }
+
+  async createAndGetUser(
+    createAccountUserInput: CreateAccountUserInput,
+  ): Promise<User> {
+    return await this.createUserAccount(createAccountUserInput);
+  }
+
+  async getAccessToken(loginInput: LoginInput): Promise<string> {
+    return (await this.authService.login(loginInput))?.result?.token;
+  }
+
+  async getOneAdopteeUser(id: number): Promise<AdopteeUser> {
+    return await this.getAdopteeUserWithExceptionHandling(id);
   }
 
   async getAdopteeUserWithExceptionHandling(id: number): Promise<AdopteeUser> {
@@ -145,12 +162,38 @@ export class UserService {
     return adopteeUser;
   }
 
+  async getAllAdopteeUser(): Promise<AdopteeUser[]> {
+    return await this.adopteeUserRepository.getAllAdopteeUser();
+  }
+
+  async getOneAdoptUser(id: number): Promise<AdoptUser> {
+    return await this.getAdoptUserWithExceptionHandling(id);
+  }
+
   async getAdoptUserWithExceptionHandling(id: number): Promise<AdoptUser> {
     const adoptUser = await this.adoptUserRepository.getOneAdoptUserById(id);
     if (!adoptUser) {
       throw new BadRequestException(`id:${id}인 업체유저는 존재하지 않습니다.`);
     }
     return adoptUser;
+  }
+
+  async getAuthenticatedAdoptUsers(
+    getAdoptUsersArgs: GetAdoptUsersArgs,
+  ): Promise<AdoptUser[]> {
+    return await this.adoptUserRepository.getAuthenticatedAdoptUsers(
+      getAdoptUsersArgs,
+    );
+  }
+
+  async deleteOneUser(id: number, user: User) {
+    user.userType === UserType.ADOPTEE
+      ? await this.getAdopteeUserWithVerifyingAuthority(id, user)
+      : await this.getAdoptUserWithVerifyingAuthority(id, user);
+    const deleteResult: DeleteRequestOutput = {
+      result: (await this.userRepository.deleteOneUserById(id)).affected,
+    };
+    return deleteResult;
   }
 
   async getAdopteeUserWithVerifyingAuthority(
@@ -173,36 +216,6 @@ export class UserService {
       throw new UnauthorizedException('해당 요청에 대한 권한이 없습니다.');
     }
     return targetUser;
-  }
-
-  async getOneAdopteeUser(id: number): Promise<AdopteeUser> {
-    return await this.getAdopteeUserWithExceptionHandling(id);
-  }
-
-  async getAllAdopteeUser(): Promise<AdopteeUser[]> {
-    return await this.adopteeUserRepository.getAllAdopteeUser();
-  }
-
-  async getOneAdoptUser(id: number): Promise<AdoptUser> {
-    return await this.getAdoptUserWithExceptionHandling(id);
-  }
-
-  async getAuthenticatedAdoptUsers(
-    getAdoptUsersArgs: GetAdoptUsersArgs,
-  ): Promise<AdoptUser[]> {
-    return await this.adoptUserRepository.getAuthenticatedAdoptUsers(
-      getAdoptUsersArgs,
-    );
-  }
-
-  async deleteOneUser(id: number, user: User) {
-    user.userType === UserType.ADOPTEE
-      ? await this.getAdopteeUserWithVerifyingAuthority(id, user)
-      : await this.getAdoptUserWithVerifyingAuthority(id, user);
-    const deleteResult: DeleteRequestOutput = {
-      result: (await this.userRepository.deleteOneUserById(id)).affected,
-    };
-    return deleteResult;
   }
 
   async updateAdopteeUser(updateInput: UpdateAdopteeUserInput, user: User) {


### PR DESCRIPTION
설계 과정에서 트랜잭션을 적용하지 않고 구현이 가능함을 확인.
 트랜잭션을 적용하지 않아도 문제가 없도록 리팩터링 진행

- 개인(AdopteeUser) 혹은 업체(AdoptUser) 유저를 생성할 때, 
  기본 유저를 먼저 만들고(Create) DB에 저장한(Save) 뒤에 
  각 타입에 맞는 유저를 생성 & 저장하는 형태로 구현을 했었음
⇒ 이런 프로세스라면 기본 유저와 각 타입 유저를 만들 때,
    원자성을 보장해주어야 하기 때문에 트랜잭션을 처리해야겠다는 생각이 들었음.

- 하지만 그럴 필요 없이 기본 유저 객체만 먼저 만든 다음, DB에 저장하지 않은 상태로 기본 유저 객체를 각 타입 유저를 만드는 프로세스에 넘겨주면 해결이 된다.
⇒ 이런 프로세스라면, 타입 유저를 만들 때 기본 유저 객체를 같이 넘겨서
    하나의 쿼리로 [기본유저, 타입유저]를 DB에 저장하게 되어 원자성을 보장할 수 있다.

8주차 개발 과정 기록 문서 공유합니다.
PM2를 이용한 백엔드 서버 무중단 서비스, 트랜잭션 관련 개념 등 정리해두었으니 필요하시면 참고해주세요 : )
[문서 링크](https://hminn.notion.site/8-PM2-3f9df66331824670918190b54839a8f7)